### PR TITLE
[FS-2988] guards against nil paths causing crashes

### DIFF
--- a/ios/Video/RCTVideo.m
+++ b/ios/Video/RCTVideo.m
@@ -696,10 +696,27 @@ static int const RCTVideoUnset = -1;
     DebugLog(@"Could not find video URL in source '%@'", source);
     return;
   }
-  
-  NSURL *url = isNetwork || isAsset
-    ? [NSURL URLWithString:uri]
-    : [[NSURL alloc] initFileURLWithPath:[[NSBundle mainBundle] pathForResource:uri ofType:type]];
+
+  NSURL *url;
+  if (isNetwork || isAsset) {
+    url = [NSURL URLWithString:uri];
+    if (!url) {
+      DebugLog(@"Invalid URL string: %@", uri);
+      return;
+    }
+  } else {
+    NSString *filePath = [[NSBundle mainBundle] pathForResource:uri ofType:type];
+    if (!filePath) {
+      DebugLog(@"File path for resource %@.%@ not found", uri, type);
+      return;
+    }
+    url = [NSURL fileURLWithPath:filePath];
+    if (!url) {
+      DebugLog(@"Failed to create file URL for path: %@", filePath);
+      return;
+    }
+  }
+
   NSMutableDictionary *assetOptions = [[NSMutableDictionary alloc] init];
   
   if (isNetwork) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "react-native-video",
-    "version": "5.1.0-alpha8-fs15",
+    "version": "5.1.0-alpha8-fs16",
     "description": "A <Video /> element for react-native",
     "main": "Video.js",
     "license": "MIT",


### PR DESCRIPTION
https://firesidechat.atlassian.net/browse/FS-2988

Determined that when vertically scrolling through conent feed, some stremium channels that have 48000 Hz audio are eventually causing the app to crash. This seems to occur mainly when swapping between sources where the audio is 44100 Hz to a source that is 48000 Hz. It does not always occur, but after about 10-12 items have been scrolled through it almost always does. It does NOT occur when ALL items are 48000 Hz or ALL items are 44100 Hz. Its the combination of the two different audio rates that produces the crash.

I don't know how to resolve the root cause, but I found that the guard PR'd here prevents the crash, though I think the side-effect is that there is an audio mismatch with audio from the previous clip playing over the new clip presented. But then swiping to the next clip seems to resolve the issue.

I guess this is better than the app crashing, right?